### PR TITLE
Fixes #37 - Allows a global HttpClient to be specified  

### DIFF
--- a/BaselineFluentHttpExtensions.cs
+++ b/BaselineFluentHttpExtensions.cs
@@ -42,11 +42,45 @@ namespace Baseline.FluentHttpExtensions
         public HttpRequest(string uri, HttpClient httpClient = default)
         {
             Uri = uri;
-            if (httpClient == null && _newClientInstance == null)
+            if (
+                httpClient == null &&
+                BaselineFluentHttpExtensionsHttpClientManager.GetGlobalHttpClient() == null &&
+                _newClientInstance == null
+            )
             {
                 _newClientInstance = new HttpClient();
             }
-            HttpClient = httpClient ?? _newClientInstance;
+            HttpClient = httpClient ??
+                         BaselineFluentHttpExtensionsHttpClientManager.GetGlobalHttpClient() ??
+                         _newClientInstance;
+        }
+    }
+}
+
+namespace Baseline.FluentHttpExtensions
+{
+    /// <summary>
+    /// Provides the ability for a consuming application to globally set the HttpClient that will be used for all
+    /// subsequent Baseline.FluentHttpExtensions.HttpRequest requests (unless an overriding HttpClient is explicitly
+    /// specified to the initiating methods/constructor).
+    /// </summary>
+    public static class BaselineFluentHttpExtensionsHttpClientManager
+    {
+        private static HttpClient _client;
+        /// <summary>
+        /// Sets the global HttpClient to use for any subsequent requests.
+        /// </summary>
+        /// <param name="client">The HttpClient instance to use.</param>
+        public static void SetGlobalHttpClient(HttpClient client)
+        {
+            _client = client;
+        }
+        /// <summary>
+        /// Gets the global HttpClient to use. If one has not been specified, this method returns null.
+        /// </summary>
+        internal static HttpClient GetGlobalHttpClient()
+        {
+            return _client;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ chain multiple method calls together to create code that is not only quick to wr
 
 ## 🛠 Documentation
 
+### Library methods
+
 **Request Methods**
 
 Request methods modify the HTTP verb of the request.
@@ -170,6 +172,47 @@ without having to make the request again.
 * `Task<T> ReadJsonResponseAs<T>()` - Deserializes the JSON content of the response into an object of type T.
 
 * `Task<T> ReadXmlResponseAs<T>()` - Deserializes the XML content of the response into an object of type T.
+
+### Controlling the HttpClient instance that is used
+
+Baseline.FluentHttpExtensions allows a pre-defined `HttpClient` instance to be optionally provided in two ways before
+defaulting back to its own static, internally managed instance.
+
+You can provide one on each instantiation of a `HttpRequest` class (or via a fluent method that instantiates it for you):
+
+```csharp
+var myHttpClient = new HttpClient();
+
+// Via constructor injection.
+await ("https://www.google.com", new HttpRequest(myHttpClient))
+    .AsAGetRequest()
+    .EnsureSuccessStatusCode();
+
+// Via a fluent method that does the instantiation for you.
+await "https://www.google.com"
+    .AsAGetRequest(myHttpClient)
+    .EnsureSuccessStatusCode();
+```
+
+OR, you can configure one globally via the `BaselineFluentHttpExtensionsHttpClientManager` static class:
+
+```csharp
+var myHttpClient = new HttpClient();
+
+BaselineFluentHttpExtensionsHttpClientManager.SetGlobalHttpClient(myHttpClient);
+
+// All future requests where an instance is not specified uses the above defined client.
+await "https://www.google.com"
+    .AsAGetRequest()
+    .EnsureSuccessStatusCode();
+
+// However, should you want to, you can still override it by providing an instance directly.
+var mySecondClient = new HttpClient();
+
+await "https://www.google.com"
+    .AsAGetRequest(mySecondClient)
+    .EnsureSuccessStatusCode();
+```
 
 ## ❔ Examples
 

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
@@ -10,7 +10,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
         public async Task Can_Make_Request_With_Auth_And_Content_Type_Headers()
         {
             var response = await "https://postman-echo.com/put"
-                .AsAPutRequest()
+                .AsAPutRequest(new HttpClient())
                 .WithTextBody("This is a test")
                 .ReadResponseAsString();
 
@@ -21,12 +21,12 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
         public async Task Can_Make_A_Request_With_Basic_Auth()
         {
             await "https://postman-echo.com/basic-auth"
-                .AsAGetRequest()
+                .AsAGetRequest(new HttpClient())
                 .WithBasicAuth("postman", "password")
                 .EnsureSuccessStatusCode();
 
             var failedResponse = await "https://postman-echo.com/basic-auth"
-                .AsAGetRequest()
+                .AsAGetRequest(new HttpClient())
                 .WithBasicAuth("postman", "wrong-password")
                 .MakeRequest();
             Assert.Throws<HttpRequestException>(() => failedResponse.EnsureSuccessStatusCode());
@@ -36,7 +36,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
         public async Task Custom_Headers_Are_Added_Correctly()
         {
             var response = await "https://postman-echo.com/headers"
-                .AsAGetRequest()
+                .AsAGetRequest(new HttpClient())
                 .WithRequestHeader("X-Custom-Header", "my-custom-header")
                 .WithUserAgent("my-compoota")
                 .WithRequestHeader("X-Help-Me", "the-robots-have-taken-over")
@@ -51,7 +51,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
         public async Task Can_Post_Json()
         {
             var response = await "https://postman-echo.com/post"
-                .AsAPostRequest()
+                .AsAPostRequest(new HttpClient())
                 .WithJsonBody(new {Id = "1", Name = "foo"})
                 .ReadResponseAsString();
 

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/JsonPlaceholderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/JsonPlaceholderTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,7 +10,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
         public async Task It_Can_Retrieve_A_User()
         {
             var user = await "https://jsonplaceholder.typicode.com/users/1"
-                .AsAGetRequest()
+                .AsAGetRequest(new HttpClient())
                 .ReadJsonResponseAs<User>();
 
             Assert.Equal(1, user.Id);

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/GlobalStaticClientTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/GlobalStaticClientTests.cs
@@ -1,0 +1,29 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit
+{
+    public class GlobalStaticClientTests : UnitTest
+    {
+        [Fact]
+        public async Task It_Uses_The_Globally_Set_Http_Client_If_Available()
+        {
+            BaselineFluentHttpExtensionsHttpClientManager.SetGlobalHttpClient(new HttpClient(MessageHandler.Object));
+
+            var messageHandlerResult = ConfigureMessageHandlerResultSuccess(
+                MessageHandler,
+                "response from a global client",
+                "text/plain"
+            );
+            OnRequestMade(r => Assert.Contains("/global/http/test", r.RequestUri.OriginalString), messageHandlerResult);
+
+            var response = await "http://www.google.com".AsAGetRequest()
+                .WithPathSegment("global")
+                .WithPathSegment("http")
+                .WithPathSegment("test")
+                .ReadResponseAsString();
+            Assert.Equal("response from a global client", response);
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/UnitTest.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/UnitTest.cs
@@ -12,16 +12,16 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit
 {
     public abstract class UnitTest
     {
-        private Mock<HttpMessageHandler> _messageHandler = new Mock<HttpMessageHandler>();
         protected const string RequestUrl = "https://www.google.com";
+        protected Mock<HttpMessageHandler> MessageHandler = new Mock<HttpMessageHandler>();
         protected HttpClient HttpClient;
         protected HttpRequest HttpRequest { get; }
         protected IReturnsResult<HttpMessageHandler> MessageHandlerResult { get; private set; }
 
         protected UnitTest()
         {
-            HttpClient = new HttpClient(_messageHandler.Object);
-            MessageHandlerResult = ConfigureMessageHandlerResultSuccess(_messageHandler);
+            HttpClient = new HttpClient(MessageHandler.Object);
+            MessageHandlerResult = ConfigureMessageHandlerResultSuccess(MessageHandler);
             HttpRequest = new HttpRequest(RequestUrl, HttpClient);
         }
 

--- a/src/Baseline.FluentHttpExtensions/BaselineFluentHttpExtensionsHttpClientManager.cs
+++ b/src/Baseline.FluentHttpExtensions/BaselineFluentHttpExtensionsHttpClientManager.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+
+namespace Baseline.FluentHttpExtensions
+{
+    /// <summary>
+    /// Provides the ability for a consuming application to globally set the HttpClient that will be used for all
+    /// subsequent Baseline.FluentHttpExtensions.HttpRequest requests (unless an overriding HttpClient is explicitly
+    /// specified to the initiating methods/constructor).
+    /// </summary>
+    public static class BaselineFluentHttpExtensionsHttpClientManager
+    {
+        private static HttpClient _client;
+
+        /// <summary>
+        /// Sets the global HttpClient to use for any subsequent requests.
+        /// </summary>
+        /// <param name="client">The HttpClient instance to use.</param>
+        public static void SetGlobalHttpClient(HttpClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
+        /// Gets the global HttpClient to use. If one has not been specified, this method returns null.
+        /// </summary>
+        internal static HttpClient GetGlobalHttpClient()
+        {
+            return _client;
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions/HttpRequest.cs
+++ b/src/Baseline.FluentHttpExtensions/HttpRequest.cs
@@ -32,12 +32,18 @@ namespace Baseline.FluentHttpExtensions
         {
             Uri = uri;
 
-            if (httpClient == null && _newClientInstance == null)
+            if (
+                httpClient == null &&
+                BaselineFluentHttpExtensionsHttpClientManager.GetGlobalHttpClient() == null &&
+                _newClientInstance == null
+            )
             {
                 _newClientInstance = new HttpClient();
             }
 
-            HttpClient = httpClient ?? _newClientInstance;
+            HttpClient = httpClient ??
+                         BaselineFluentHttpExtensionsHttpClientManager.GetGlobalHttpClient() ??
+                         _newClientInstance;
         }
     }
 }


### PR DESCRIPTION
Added a `BaselineFluentHttpExtensionsHttpClientManager` class that allows a consuming
application to specify a `HttpClient` instance that should be used for all future
created `HttpRequest` instances.

Fixed a number of tests that broke due to that change.

Added a new test to ensure setting a global client works as expected.
