### PR TITLE
Fixes #46 - Allow URLs to be built prior to the execution of the requ…

### DIFF
--- a/BaselineFluentHttpExtensions.cs
+++ b/BaselineFluentHttpExtensions.cs
@@ -146,6 +146,51 @@ namespace Baseline.FluentHttpExtensions
 namespace Baseline.FluentHttpExtensions
 {
     /// <summary>
+    /// Extension methods related to the building of things, such as URIs. Allows consumers to make business logic
+    /// decisions without having to physically submit a request.
+    /// </summary>
+    public static class BuilderExtensions
+    {
+        /// <summary>
+        /// Builds the URI from parameters defined in the request such as the base URI, path segments, query string
+        /// parameters etc without submitting the request.
+        /// </summary>
+        /// <param name="request">The configured request to build the URI from.</param>
+        /// <returns>A built URI, equivalent to what will be sent via the HttpClient.</returns>
+        public static Uri BuildUri(this HttpRequest request)
+        {
+            var uri = new UriBuilder(request.Uri);
+            if (request.QueryParameters != null)
+            {
+                var queryStringParameters = HttpUtility.ParseQueryString(uri.Query);
+                foreach (var (name, value) in request.QueryParameters)
+                {
+                    queryStringParameters.Add(name, value);
+                }
+                uri.Query = queryStringParameters.ToString();
+            }
+            if (request.PathSegments != null)
+            {
+                uri.Path += string.Join("/", request.PathSegments);
+            }
+            return uri.Uri;
+        }
+        /// <summary>
+        /// Builds a URI from the parameters defined in the request such as the base URI, path segments, query string
+        /// parameters etc without submitting the request.
+        /// </summary>
+        /// <param name="request">The configured request to build the URI from.</param>
+        /// <returns>A built URI, equivalent to what will be sent via the HttpClient, in a string format.</returns>
+        public static string BuildUriAsString(this HttpRequest request)
+        {
+            return request.BuildUri().ToString();
+        }
+    }
+}
+
+namespace Baseline.FluentHttpExtensions
+{
+    /// <summary>
     /// Contains any and all extensions related to request headers.
     /// </summary>
     public static class HeaderExtensions
@@ -437,22 +482,7 @@ namespace Baseline.FluentHttpExtensions
             CancellationToken token = default
         )
         {
-            // Build Uri from Uri and query string parameters.
-            var uri = new UriBuilder(request.Uri);
-            if (request.QueryParameters != null)
-            {
-                var queryStringParameters = HttpUtility.ParseQueryString(uri.Query);
-                foreach (var (name, value) in request.QueryParameters)
-                {
-                    queryStringParameters.Add(name, value);
-                }
-                uri.Query = queryStringParameters.ToString();
-            }
-            if (request.PathSegments != null)
-            {
-                uri.Path += string.Join("/", request.PathSegments);
-            }
-            var actualRequest = new HttpRequestMessage(request.HttpMethod, uri.Uri);
+            var actualRequest = new HttpRequestMessage(request.HttpMethod, request.BuildUri());
             // Build headers.
             if (request.Headers != null)
             {

--- a/README.md
+++ b/README.md
@@ -78,21 +78,21 @@ Extension methods of the built in type `string`, these methods allow you to quic
 without calling the `HttpRequest` constructor. You can optionally pass in a `HttpClient` instance which will be used
 instead. If you don't, a static one handled inside of `Baseline.FluentHttpExtensions` will be used instead.
 
-* `"abc".AsAGetRequest(HttpClient? client = default)` - Creates a GET request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsAGetRequest(HttpClient? client = default)` - Creates a GET request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsAPostRequest(HttpClient? client = default)`  - Creates a POST request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsAPostRequest(HttpClient? client = default)`  - Creates a POST request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsAPutRequest(HttpClient? client = default)` - Creates a PUT request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsAPutRequest(HttpClient? client = default)` - Creates a PUT request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsAPatchRequest(HttpClient? client = default)` - Creates a PATCH request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsAPatchRequest(HttpClient? client = default)` - Creates a PATCH request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsADeleteRequest(HttpClient? client = default)` - Creates a DELETE request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsADeleteRequest(HttpClient? client = default)` - Creates a DELETE request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsATraceRequest(HttpClient? client = default)` - Creates a TRACE request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsATraceRequest(HttpClient? client = default)` - Creates a TRACE request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsAHeadRequest(HttpClient? client = default)` - Creates a HEAD request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsAHeadRequest(HttpClient? client = default)` - Creates a HEAD request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
-* `"abc".AsAnOptionsRequest(HttpClient? client = default)` - Creates an OPTIONS request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
+* `"https://www.google.com".AsAnOptionsRequest(HttpClient? client = default)` - Creates an OPTIONS request with an optional `HttpClient` and returns a configured `HttpRequest` instance.
 
 **URL Methods**
 
@@ -140,6 +140,18 @@ to `application/json`. If replace is specified, the `Content-Type` response head
 
 * `WithTextBody(string body, string contentType = "text/plain")` - Sets the request's body to `body` and sets the
 `Content-Type` header to `contentType`.
+
+**Builder Methods**
+
+Builder methods allow you to build components such as the finalised URI this library generates without having to physically
+submit the request first. These extension methods are used internally by other extension methods such as `MakeRequest`,
+so all responses returned from builder methods are exactly what will be used elsewhere and can be depended on.
+
+* `Uri BuildUri()` - Generates and returns the URI that will be used when the request is sent. Using this method does
+not stop you from adding more parameters to the `HttpRequest`, but it will not be updated automatically.
+
+* `string BuildUriAsString()` - Generates and returns the URI that will be used when the request is sent in a string
+format. Under the hood, this method utilises the `BuildUri` extension method.
 
 **Send Triggering Methods**
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithJsonBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithJsonBodyTests.cs
@@ -2,10 +2,11 @@ using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
+
 // ReSharper disable NotNullMemberIsNotInitialized
 #pragma warning disable 8618
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
 {
     public class TestBody
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithTextBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithTextBodyTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
 {
     public class WithTextBodyTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriAsStringTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriAsStringTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.BuilderExtensionsTests
+{
+    public class BuildUriAsStringTests
+    {
+        [Fact]
+        public void It_Successfully_Builds_And_Returns_A_Uri()
+        {
+            var response = "https://www.google.com/"
+                .AsAGetRequest()
+                .WithPathSegment("search")
+                .WithQueryParameter("q", "how much does a pug snore")
+                .BuildUriAsString();
+
+            Assert.Equal("https://www.google.com/search?q=how+much+does+a+pug+snore", response);
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.BuilderExtensionsTests
+{
+    public class BuildUriTests
+    {
+        [Fact]
+        public void It_Successfully_Builds_And_Returns_A_Uri()
+        {
+            var response = "https://www.google.com/"
+                .AsAGetRequest()
+                .WithPathSegment("search")
+                .WithQueryParameter("q", "how much does a pug snore")
+                .BuildUri();
+
+            Assert.Equal("https://www.google.com/search?q=how+much+does+a+pug+snore", response.ToString());
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Moq;
 using Xunit;
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 {
     public class EnsureSuccessStatusCodeTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/MakeRequestTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/MakeRequestTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 {
     public class MakeRequestTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
@@ -2,11 +2,12 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Moq;
 using Xunit;
+
 // ReSharper disable NotNullMemberIsNotInitialized
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 #pragma warning disable 8618
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 {
     public class ReadJsonResponseAsTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Moq;
 using Xunit;
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 {
     public class ReadResponseAsStringTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
@@ -4,7 +4,7 @@ using System.Xml.Serialization;
 using Moq;
 using Xunit;
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 {
     public class ReadXmlResponseAsTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/StringToHttpRequestExtensionsTests/StringToHttpRequestExtensionTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/StringToHttpRequestExtensionsTests/StringToHttpRequestExtensionTests.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Baseline.FluentHttpExtensions.Tests.Unit.StringToHttpRequestExtensions
+namespace Baseline.FluentHttpExtensions.Tests.Unit.StringToHttpRequestExtensionsTests
 {
     public class StringToHttpRequestExtensionTests : UnitTest
     {

--- a/src/Baseline.FluentHttpExtensions/BuilderExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/BuilderExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Web;
+
+namespace Baseline.FluentHttpExtensions
+{
+    /// <summary>
+    /// Extension methods related to the building of things, such as URIs. Allows consumers to make business logic
+    /// decisions without having to physically submit a request.
+    /// </summary>
+    public static class BuilderExtensions
+    {
+        /// <summary>
+        /// Builds the URI from parameters defined in the request such as the base URI, path segments, query string
+        /// parameters etc without submitting the request.
+        /// </summary>
+        /// <param name="request">The configured request to build the URI from.</param>
+        /// <returns>A built URI, equivalent to what will be sent via the HttpClient.</returns>
+        public static Uri BuildUri(this HttpRequest request)
+        {
+            var uri = new UriBuilder(request.Uri);
+
+            if (request.QueryParameters != null)
+            {
+                var queryStringParameters = HttpUtility.ParseQueryString(uri.Query);
+
+                foreach (var (name, value) in request.QueryParameters)
+                {
+                    queryStringParameters.Add(name, value);
+                }
+
+                uri.Query = queryStringParameters.ToString();
+            }
+
+            if (request.PathSegments != null)
+            {
+                uri.Path += string.Join("/", request.PathSegments);
+            }
+
+            return uri.Uri;
+        }
+
+        /// <summary>
+        /// Builds a URI from the parameters defined in the request such as the base URI, path segments, query string
+        /// parameters etc without submitting the request.
+        /// </summary>
+        /// <param name="request">The configured request to build the URI from.</param>
+        /// <returns>A built URI, equivalent to what will be sent via the HttpClient, in a string format.</returns>
+        public static string BuildUriAsString(this HttpRequest request)
+        {
+            return request.BuildUri().ToString();
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions/SendTriggeringExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/SendTriggeringExtensions.cs
@@ -23,26 +23,7 @@ namespace Baseline.FluentHttpExtensions
             CancellationToken token = default
         )
         {
-            // Build Uri from Uri and query string parameters.
-            var uri = new UriBuilder(request.Uri);
-            if (request.QueryParameters != null)
-            {
-                var queryStringParameters = HttpUtility.ParseQueryString(uri.Query);
-
-                foreach (var (name, value) in request.QueryParameters)
-                {
-                    queryStringParameters.Add(name, value);
-                }
-
-                uri.Query = queryStringParameters.ToString();
-            }
-
-            if (request.PathSegments != null)
-            {
-                uri.Path += string.Join("/", request.PathSegments);
-            }
-
-            var actualRequest = new HttpRequestMessage(request.HttpMethod, uri.Uri);
+            var actualRequest = new HttpRequestMessage(request.HttpMethod, request.BuildUri());
 
             // Build headers.
             if (request.Headers != null)


### PR DESCRIPTION
…est.

Added a new `BuilderExtensions` file that builds things (duh). Within this file, add two new extension methods:
	* BuildUri - builds the URI and returns it as the Uri type.
	* BuildUriAsString - builds the URI but returns it as a string.

Added tests for the new methods.

Updated namespaces of some other tests.

Fixes #46 