### PR TITLE
Issue #43 - Suffix asynchronous methods with Async.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,19 +158,19 @@ format. Under the hood, this method utilises the `BuildUri` extension method.
 The send triggering methods perform the actual request to the configured endpoint. For that reason, they do not
 continue the fluent interface and return response types relevant to their methods.
 
-* `Task<HttpResponseMessage> MakeRequest()` - Performs the request using the configured parameters and returns the
+* `Task<HttpResponseMessage> MakeRequestAsync()` - Performs the request using the configured parameters and returns the
 response.
 
-* `Task EnsureSuccessStatusCode()` - Performs the request and calls `.EnsureSuccessStatusCode()` on the returned
+* `Task EnsureSuccessStatusCodeAsync()` - Performs the request and calls `.EnsureSuccessStatusCode()` on the returned
 response.
 
-* `Task<string> ReadResponseAsString()` - Performs the request and reads the request as a string. This method first
+* `Task<string> ReadResponseAsStringAsync()` - Performs the request and reads the request as a string. This method first
 ensures that the status code returned is a successful one.
 
-* `Task<T> ReadJsonResponseAs<T>()` - Performs the request and deserializes the JSON response into an object of type T.
+* `Task<T> ReadJsonResponseAsAsync<T>()` - Performs the request and deserializes the JSON response into an object of type T.
 This method first ensures that the status code returned is a successful one.
 
-* `Task<T> ReadXmlResponseAs<T>()` - Performs the request and Deserializes the XML content of the response into an
+* `Task<T> ReadXmlResponseAsAsync<T>()` - Performs the request and Deserializes the XML content of the response into an
 object of type T. This method first ensures that the status code returned is a successful one.
 
 **HttpResponseMessage Methods**
@@ -179,11 +179,11 @@ Occasionally, you may want to perform more than one action on a `HttpResponseMes
 method. The following methods allow you to do that against a `HttpResponseMessage` saved in a variable multiple times,
 without having to make the request again.
 
-* `Task<string> ReadResponseAsString()` - Reads the content of the response as a string.
+* `Task<string> ReadResponseAsStringAsync()` - Reads the content of the response as a string.
 
-* `Task<T> ReadJsonResponseAs<T>()` - Deserializes the JSON content of the response into an object of type T.
+* `Task<T> ReadJsonResponseAsAsync<T>()` - Deserializes the JSON content of the response into an object of type T.
 
-* `Task<T> ReadXmlResponseAs<T>()` - Deserializes the XML content of the response into an object of type T.
+* `Task<T> ReadXmlResponseAsAsync<T>()` - Deserializes the XML content of the response into an object of type T.
 
 ### Controlling the HttpClient instance that is used
 
@@ -198,12 +198,12 @@ var myHttpClient = new HttpClient();
 // Via constructor injection.
 await ("https://www.google.com", new HttpRequest(myHttpClient))
     .AsAGetRequest()
-    .EnsureSuccessStatusCode();
+    .EnsureSuccessStatusCodeAsync();
 
 // Via a fluent method that does the instantiation for you.
 await "https://www.google.com"
     .AsAGetRequest(myHttpClient)
-    .EnsureSuccessStatusCode();
+    .EnsureSuccessStatusCodeAsync();
 ```
 
 OR, you can configure one globally via the `BaselineFluentHttpExtensionsHttpClientManager` static class:
@@ -216,28 +216,23 @@ BaselineFluentHttpExtensionsHttpClientManager.SetGlobalHttpClient(myHttpClient);
 // All future requests where an instance is not specified uses the above defined client.
 await "https://www.google.com"
     .AsAGetRequest()
-    .EnsureSuccessStatusCode();
+    .EnsureSuccessStatusCodeAsync();
 
 // However, should you want to, you can still override it by providing an instance directly.
 var mySecondClient = new HttpClient();
 
 await "https://www.google.com"
     .AsAGetRequest(mySecondClient)
-    .EnsureSuccessStatusCode();
+    .EnsureSuccessStatusCodeAsync();
 ```
 
 ## ❔ Examples
 
-**Daily cat facts**
-
 ```csharp
-var catFacts = await "https://cat-fact.herokuapp.com"
+var user = await "https://jsonplaceholder.typicode.com/users/1"
     .AsAGetRequest()
-    .WithPathSegment("facts")
-    .ReadResponseAsString();
+    .ReadJsonResponseAsAsync<User>();
 
-Console.WriteLine(catFacts);
-
-> {"all":[{"_id":"58e008ad0aac31001185ed0c","text":"The frequency of a domestic cat's purr is the same at which ..........
-
+Console.WriteLine(user.Id);
+Console.WriteLine(user.Name);
 ```

--- a/src/Baseline.FluentHttpExtensions.CombinedFileTests/CombinedFileJsonPlaceholderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.CombinedFileTests/CombinedFileJsonPlaceholderTests.cs
@@ -10,7 +10,7 @@ namespace Baseline.FluentHttpExtensions.CombinedFileTests
         {
             var user = await "https://jsonplaceholder.typicode.com/users/1"
                 .AsAGetRequest()
-                .ReadJsonResponseAs<User>();
+                .ReadJsonResponseAsAsync<User>();
 
             Assert.Equal(1, user.Id);
             Assert.Equal("Leanne Graham", user.Name);

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
@@ -12,7 +12,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
             var response = await "https://postman-echo.com/put"
                 .AsAPutRequest(new HttpClient())
                 .WithTextBody("This is a test")
-                .ReadResponseAsString();
+                .ReadResponseAsStringAsync();
 
             Assert.Contains("This is a test", response);
         }
@@ -23,12 +23,12 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
             await "https://postman-echo.com/basic-auth"
                 .AsAGetRequest(new HttpClient())
                 .WithBasicAuth("postman", "password")
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
 
             var failedResponse = await "https://postman-echo.com/basic-auth"
                 .AsAGetRequest(new HttpClient())
                 .WithBasicAuth("postman", "wrong-password")
-                .MakeRequest();
+                .MakeRequestAsync();
             Assert.Throws<HttpRequestException>(() => failedResponse.EnsureSuccessStatusCode());
         }
 
@@ -40,7 +40,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
                 .WithRequestHeader("X-Custom-Header", "my-custom-header")
                 .WithUserAgent("my-compoota")
                 .WithRequestHeader("X-Help-Me", "the-robots-have-taken-over")
-                .ReadResponseAsString();
+                .ReadResponseAsStringAsync();
 
             Assert.Contains(@"""x-custom-header"":""my-custom-header""", response);
             Assert.Contains(@"""user-agent"":""my-compoota""", response);
@@ -53,7 +53,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
             var response = await "https://postman-echo.com/post"
                 .AsAPostRequest(new HttpClient())
                 .WithJsonBody(new {Id = "1", Name = "foo"})
-                .ReadResponseAsString();
+                .ReadResponseAsStringAsync();
 
             Assert.Contains(@"""Id"":""1""", response);
             Assert.Contains(@"""Name"":""foo""", response);

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/JsonPlaceholderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/JsonPlaceholderTests.cs
@@ -11,7 +11,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
         {
             var user = await "https://jsonplaceholder.typicode.com/users/1"
                 .AsAGetRequest(new HttpClient())
-                .ReadJsonResponseAs<User>();
+                .ReadJsonResponseAsAsync<User>();
 
             Assert.Equal(1, user.Id);
             Assert.Equal("Leanne Graham", user.Name);

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/ActionExtensionsTests/RequestMethodTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/ActionExtensionsTests/RequestMethodTests.cs
@@ -29,7 +29,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.ActionExtensionsTests
 
             // Arrange & Act.
             await handler(HttpRequest)
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithJsonBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithJsonBodyTests.cs
@@ -43,7 +43,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
             await HttpRequest
                 .AsAGetRequest()
                 .WithJsonBody(new TestBody {Name = "Bob Smith", Age = 47})
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithTextBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithTextBodyTests.cs
@@ -36,7 +36,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
 
             await HttpRequest
                 .WithTextBody("abc")
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/GlobalStaticClientTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/GlobalStaticClientTests.cs
@@ -22,7 +22,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit
                 .WithPathSegment("global")
                 .WithPathSegment("http")
                 .WithPathSegment("test")
-                .ReadResponseAsString();
+                .ReadResponseAsStringAsync();
             Assert.Equal("response from a global client", response);
         }
     }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/ResponseContentTypeTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/ResponseContentTypeTests.cs
@@ -28,7 +28,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
                 OnRequestMade(r => Assert.Equal(methodAndExpected.expected, r.Headers.Accept.ToString()), handlerResult);
 
                 await methodAndExpected.Item1(request)
-                    .EnsureSuccessStatusCode();
+                    .EnsureSuccessStatusCodeAsync();
             }
         }
 
@@ -55,7 +55,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
                 OnRequestMade(r => Assert.Equal(methodAndExpected.expected, r.Headers.Accept.ToString()), handlerResult);
 
                 await methodAndExpected.Item1(request)
-                    .EnsureSuccessStatusCode();
+                    .EnsureSuccessStatusCodeAsync();
             }
         }
 
@@ -78,7 +78,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
                 OnRequestMade(r => Assert.Equal(methodAndExpected.expected, r.Headers.Accept.ToString()), handlerResult);
 
                 await methodAndExpected.Item1(request)
-                    .EnsureSuccessStatusCode();
+                    .EnsureSuccessStatusCodeAsync();
             }
         }
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBasicAuthTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBasicAuthTests.cs
@@ -20,7 +20,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
 
             await HttpRequest
                 .WithBasicAuth("baseline", "http")
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBearerTokenAuthTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBearerTokenAuthTests.cs
@@ -14,7 +14,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
 
             await HttpRequest
                 .WithBearerTokenAuth(token)
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithHeaderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithHeaderTests.cs
@@ -13,7 +13,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
             await HttpRequest
                 .WithRequestHeader("Authorization", "Bearer foo-bar")
                 .AsAGetRequest()
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
                 .WithRequestHeader("Authorization", "Bearer foo")
                 .WithRequestHeader("Authorization", "Bearer bar")
                 .AsAGetRequest()
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithUserAgentTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithUserAgentTests.cs
@@ -13,7 +13,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
             await HttpRequest
                 .WithUserAgent("baseline")
                 .AsAGetRequest()
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
@@ -16,7 +16,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
             // Act.
-            async Task Act() => await request.EnsureSuccessStatusCode();
+            async Task Act() => await request.EnsureSuccessStatusCodeAsync();
 
             // Assert.
             await Assert.ThrowsAsync<HttpRequestException>(Act);
@@ -26,7 +26,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         public async Task Good_Status_Code_Doesnt_Return_An_Error()
         {
             // Arrange, Act & Assert.
-            await HttpRequest.EnsureSuccessStatusCode();
+            await HttpRequest.EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/MakeRequestTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/MakeRequestTests.cs
@@ -11,7 +11,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         {
             var response = await HttpRequest
                 .AsAGetRequest()
-                .MakeRequest();
+                .MakeRequestAsync();
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
@@ -20,7 +20,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
             // Act.
-            async Task Act() => await request.ReadJsonResponseAs<object>();
+            async Task Act() => await request.ReadJsonResponseAsAsync<object>();
 
             // Assert.
             await Assert.ThrowsAsync<HttpRequestException>(Act);
@@ -44,7 +44,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 
             // Act.
             var response = await request
-                .ReadJsonResponseAs<ResolvedObject>();
+                .ReadJsonResponseAsAsync<ResolvedObject>();
 
             // Assert.
             Assert.NotNull(response);

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
@@ -16,7 +16,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
             // Act.
-            async Task Act() => await request.ReadResponseAsString();
+            async Task Act() => await request.ReadResponseAsStringAsync();
 
             // Assert.
             await Assert.ThrowsAsync<HttpRequestException>(Act);
@@ -31,7 +31,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
             // Act.
-            var response = await request.ReadResponseAsString();
+            var response = await request.ReadResponseAsStringAsync();
 
             // Assert.
             Assert.Equal("hello world", response);

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
@@ -17,7 +17,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
             // Act.
-            async Task Act() => await request.ReadXmlResponseAs<object>();
+            async Task Act() => await request.ReadXmlResponseAsAsync<object>();
 
             // Assert.
             await Assert.ThrowsAsync<HttpRequestException>(Act);
@@ -32,7 +32,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
             // Act.
-            var response = await request.ReadXmlResponseAs<TestXmlObject>();
+            var response = await request.ReadXmlResponseAsAsync<TestXmlObject>();
 
             // Assert.
             Assert.NotNull(response);

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/StringToHttpRequestExtensionsTests/StringToHttpRequestExtensionTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/StringToHttpRequestExtensionsTests/StringToHttpRequestExtensionTests.cs
@@ -28,7 +28,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.StringToHttpRequestExtensions
         {
             OnRequestMade(r => Assert.Equal(expected, r.Method));
 
-            await func(Url, HttpClient).EnsureSuccessStatusCode();
+            await func(Url, HttpClient).EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithPathSegmentTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithPathSegmentTests.cs
@@ -22,7 +22,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
                 .WithPathSegment((long)25)
                 .WithPathSegment(ulong.MaxValue)
                 .WithPathSegment("fivebillion")
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
                 .WithPathSegment("three")
                 .WithPathSegment("two")
                 .WithQueryParameter("b", "2")
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithQueryParameterTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithQueryParameterTests.cs
@@ -13,7 +13,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
 
             await HttpRequest
                 .WithQueryParameter("a", "b")
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
                 .WithQueryParameter("bingo", guid)
                 .WithQueryParameter("bar", (short)3)
                 .WithQueryParameter("bus", ulong.MaxValue)
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
                 .WithQueryParameter("a", "c")
                 .WithQueryParameter("c", 5)
                 .WithQueryParameter("c", (ushort)55)
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
                 .WithQueryParameter("c", " ")
                 .WithQueryParameter("d", "3")
                 .WithQueryParameter("e", string.Empty)
-                .EnsureSuccessStatusCode();
+                .EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions/BodyContentExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/BodyContentExtensions.cs
@@ -27,7 +27,7 @@ namespace Baseline.FluentHttpExtensions
                 throw new ArgumentNullException(nameof(body));
             }
 
-            request.GetBodyContent = async token =>
+            request.GetBodyContentAsync = async token =>
             {
                 // No, I don't need to have a using statement. StreamContent will automatically dispose of it when
                 // .Dispose() is called on it.
@@ -65,7 +65,7 @@ namespace Baseline.FluentHttpExtensions
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            request.GetBodyContent = _ =>
+            request.GetBodyContentAsync = _ =>
                 Task.FromResult((HttpContent) new StringContent(body, Encoding.UTF8, contentType));
 
             return request;

--- a/src/Baseline.FluentHttpExtensions/HttpRequest.cs
+++ b/src/Baseline.FluentHttpExtensions/HttpRequest.cs
@@ -20,7 +20,7 @@ namespace Baseline.FluentHttpExtensions
         internal Dictionary<string, string> Headers { get; set; }
         internal List<string> PathSegments { get; set; }
         internal List<(string Name, string Value)> QueryParameters { get; set; }
-        internal Func<CancellationToken, Task<HttpContent>> GetBodyContent { get; set; }
+        internal Func<CancellationToken, Task<HttpContent>> GetBodyContentAsync { get; set; }
 
         /// <summary>
         /// Initialises a new instance of the <see cref="HttpRequest"/> struct with a base URI and an optional,

--- a/src/Baseline.FluentHttpExtensions/HttpResponseMessageExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/HttpResponseMessageExtensions.cs
@@ -18,7 +18,7 @@ namespace Baseline.FluentHttpExtensions
         /// </summary>
         /// <param name="response">The response message.</param>
         /// <returns>An awaitable task yielding the response as a string.</returns>
-        public static async Task<string> ReadResponseAsString(
+        public static async Task<string> ReadResponseAsStringAsync(
             this HttpResponseMessage response
         )
         {
@@ -33,7 +33,7 @@ namespace Baseline.FluentHttpExtensions
         /// <param name="token">The optional cancellation token</param>
         /// <typeparam name="T">The type to deserialize the JSON into.</typeparam>
         /// <returns>An awaitable task yielding the deserialized object.</returns>
-        public static async Task<T> ReadJsonResponseAs<T>(
+        public static async Task<T> ReadJsonResponseAsAsync<T>(
             this HttpResponseMessage response,
             JsonSerializerOptions jsonSerializerOptions = null,
             CancellationToken token = default
@@ -54,7 +54,7 @@ namespace Baseline.FluentHttpExtensions
         /// </summary>
         /// <param name="response">The response to retrieve the content from and deserialize.</param>
         /// <returns>The deserialized representation of the XML, or null if it could not be casted.</returns>
-        public static async Task<T> ReadXmlResponseAs<T>(
+        public static async Task<T> ReadXmlResponseAsAsync<T>(
             this HttpResponseMessage response
         ) where T : class
         {

--- a/src/Baseline.FluentHttpExtensions/SendTriggeringExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/SendTriggeringExtensions.cs
@@ -18,7 +18,7 @@ namespace Baseline.FluentHttpExtensions
         /// <param name="request">The current <see cref="HttpRequest"/>.</param>
         /// <param name="token">The optional cancellation token</param>
         /// <returns>The response returned from the actioned request.</returns>
-        public static async Task<HttpResponseMessage> MakeRequest(
+        public static async Task<HttpResponseMessage> MakeRequestAsync(
             this HttpRequest request,
             CancellationToken token = default
         )
@@ -35,9 +35,9 @@ namespace Baseline.FluentHttpExtensions
             }
 
             // Set body.
-            if (request.GetBodyContent != null)
+            if (request.GetBodyContentAsync != null)
             {
-                actualRequest.Content = await request.GetBodyContent(token);
+                actualRequest.Content = await request.GetBodyContentAsync(token);
             }
 
             return await request.HttpClient.SendAsync(actualRequest, token).ConfigureAwait(false);
@@ -50,9 +50,9 @@ namespace Baseline.FluentHttpExtensions
         /// <param name="request">The configured request to make.</param>
         /// <param name="token">The optional cancellation token</param>
         /// <returns>An awaitable task.</returns>
-        public static async Task EnsureSuccessStatusCode(this HttpRequest request, CancellationToken token = default)
+        public static async Task EnsureSuccessStatusCodeAsync(this HttpRequest request, CancellationToken token = default)
         {
-            using (var response = await request.MakeRequest(token).ConfigureAwait(false))
+            using (var response = await request.MakeRequestAsync(token).ConfigureAwait(false))
             {
                 response.EnsureSuccessStatusCode();
             }
@@ -65,13 +65,13 @@ namespace Baseline.FluentHttpExtensions
         /// <param name="request">The configured request to make.</param>
         /// <param name="token">The optional cancellation token</param>
         /// <returns>An awaitable task yielding the response as a string.</returns>
-        public static async Task<string> ReadResponseAsString(this HttpRequest request,
+        public static async Task<string> ReadResponseAsStringAsync(this HttpRequest request,
             CancellationToken token = default)
         {
-            using (var response = await request.MakeRequest(token).ConfigureAwait(false))
+            using (var response = await request.MakeRequestAsync(token).ConfigureAwait(false))
             {
                 response.EnsureSuccessStatusCode();
-                return await response.ReadResponseAsString().ConfigureAwait(false);
+                return await response.ReadResponseAsStringAsync().ConfigureAwait(false);
             }
         }
 
@@ -84,16 +84,16 @@ namespace Baseline.FluentHttpExtensions
         /// <param name="token">The optional cancellation token</param>
         /// <typeparam name="T">The type to deserialize the JSON into.</typeparam>
         /// <returns>An awaitable task yielding the deserialized object.</returns>
-        public static async Task<T> ReadJsonResponseAs<T>(
+        public static async Task<T> ReadJsonResponseAsAsync<T>(
             this HttpRequest request,
             JsonSerializerOptions jsonSerializerOptions = null,
             CancellationToken token = default
         )
         {
-            using (var response = await request.MakeRequest(token).ConfigureAwait(false))
+            using (var response = await request.MakeRequestAsync(token).ConfigureAwait(false))
             {
                 response.EnsureSuccessStatusCode();
-                return await response.ReadJsonResponseAs<T>(jsonSerializerOptions, token).ConfigureAwait(false);
+                return await response.ReadJsonResponseAsAsync<T>(jsonSerializerOptions, token).ConfigureAwait(false);
             }
         }
 
@@ -104,15 +104,15 @@ namespace Baseline.FluentHttpExtensions
         /// <param name="request">The configured request to make.</param>
         /// <param name="token">The optional cancellation token.</param>
         /// <returns>The deserialized representation of the XML, or null if it could not be casted.</returns>
-        public static async Task<T> ReadXmlResponseAs<T>(
+        public static async Task<T> ReadXmlResponseAsAsync<T>(
             this HttpRequest request,
             CancellationToken token = default
         ) where T : class
         {
-            using (var response = await request.MakeRequest(token).ConfigureAwait(false))
+            using (var response = await request.MakeRequestAsync(token).ConfigureAwait(false))
             {
                 response.EnsureSuccessStatusCode();
-                return await response.ReadXmlResponseAs<T>().ConfigureAwait(false);
+                return await response.ReadXmlResponseAsAsync<T>().ConfigureAwait(false);
             }
         }
     }

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -6,5 +6,6 @@ echo "Running pre-commit hook: Generating combined BaselineFluentHttpExtensions.
 cd src/Baseline.FluentHttpExtensions.FileCombiner/ && \
     dotnet run && \
     cd ../../ && \
-    git add BaselineFluentHttpExtensions.cs;
+    git add BaselineFluentHttpExtensions.cs && \
+    cp BaselineFluentHttpExtensions.cs src/Baseline.FluentHttpExtensions.CombinedFileTests/;
 echo "Running pre-commit hook: Finished combining BaselineFluentHttpExtensions.cs file."


### PR DESCRIPTION
Added the `Async` suffix to all asynchronous methods.

Modified the tests so they work.

Updated the README to ensure it reflects the correct method names.

Fixes #43 