### PR TITLE
Issue #44 - Use FluentAssertions within tests

### DIFF
--- a/src/Baseline.FluentHttpExtensions.CombinedFileTests/Baseline.FluentHttpExtensions.CombinedFileTests.csproj
+++ b/src/Baseline.FluentHttpExtensions.CombinedFileTests/Baseline.FluentHttpExtensions.CombinedFileTests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/Baseline.FluentHttpExtensions.CombinedFileTests/CombinedFileJsonPlaceholderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.CombinedFileTests/CombinedFileJsonPlaceholderTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.CombinedFileTests
@@ -12,8 +13,8 @@ namespace Baseline.FluentHttpExtensions.CombinedFileTests
                 .AsAGetRequest()
                 .ReadJsonResponseAsAsync<User>();
 
-            Assert.Equal(1, user.Id);
-            Assert.Equal("Leanne Graham", user.Name);
+            user.Id.Should().Be(1);
+            user.Name.Should().Be("Leanne Graham");
         }
     }
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Baseline.FluentHttpExtensions.Tests.csproj
+++ b/src/Baseline.FluentHttpExtensions.Tests/Baseline.FluentHttpExtensions.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
@@ -14,7 +16,7 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
                 .WithTextBody("This is a test")
                 .ReadResponseAsStringAsync();
 
-            Assert.Contains("This is a test", response);
+            response.Should().Contain("This is a test");
         }
 
         [Fact]
@@ -25,11 +27,12 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
                 .WithBasicAuth("postman", "password")
                 .EnsureSuccessStatusCodeAsync();
 
-            var failedResponse = await "https://postman-echo.com/basic-auth"
+            Func<Task> func = async () => await "https://postman-echo.com/basic-auth"
                 .AsAGetRequest(new HttpClient())
-                .WithBasicAuth("postman", "wrong-password")
-                .MakeRequestAsync();
-            Assert.Throws<HttpRequestException>(() => failedResponse.EnsureSuccessStatusCode());
+                .WithBasicAuth("postman", "wrong-pwd")
+                .EnsureSuccessStatusCodeAsync();
+
+            await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
@@ -42,9 +45,9 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
                 .WithRequestHeader("X-Help-Me", "the-robots-have-taken-over")
                 .ReadResponseAsStringAsync();
 
-            Assert.Contains(@"""x-custom-header"":""my-custom-header""", response);
-            Assert.Contains(@"""user-agent"":""my-compoota""", response);
-            Assert.Contains(@"""x-help-me"":""the-robots-have-taken-over""", response);
+            response.Should().Contain(@"""x-custom-header"":""my-custom-header""");
+            response.Should().Contain(@"""user-agent"":""my-compoota""");
+            response.Should().Contain(@"""x-help-me"":""the-robots-have-taken-over""");
         }
 
         [Fact]
@@ -55,8 +58,8 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
                 .WithJsonBody(new {Id = "1", Name = "foo"})
                 .ReadResponseAsStringAsync();
 
-            Assert.Contains(@"""Id"":""1""", response);
-            Assert.Contains(@"""Name"":""foo""", response);
+            response.Should().Contain(@"""Id"":""1""");
+            response.Should().Contain(@"""Name"":""foo""");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/JsonPlaceholderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/JsonPlaceholderTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
@@ -13,8 +14,8 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
                 .AsAGetRequest(new HttpClient())
                 .ReadJsonResponseAsAsync<User>();
 
-            Assert.Equal(1, user.Id);
-            Assert.Equal("Leanne Graham", user.Name);
+            user.Id.Should().Be(1);
+            user.Name.Should().Be("Leanne Graham");
         }
     }
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/ActionExtensionsTests/RequestMethodTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/ActionExtensionsTests/RequestMethodTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.ActionExtensionsTests
@@ -25,11 +26,10 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.ActionExtensionsTests
         public async Task Can_Set_Request_Methods_Correctly(Func<HttpRequest, HttpRequest> handler, HttpMethod expected)
         {
             // Assert.
-            OnRequestMade(r => Assert.Equal(expected.Method, r.Method.Method));
+            OnRequestMade(r => r.Method.Method.Should().Be(expected.Method));
 
             // Arrange & Act.
-            await handler(HttpRequest)
-                .EnsureSuccessStatusCodeAsync();
+            await handler(HttpRequest).EnsureSuccessStatusCodeAsync();
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithJsonBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithJsonBodyTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 // ReSharper disable NotNullMemberIsNotInitialized
@@ -20,10 +21,10 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
         public void Null_Argument_Results_In_An_Exception_Being_Thrown()
         {
             // Arrange.
-            void Act() => HttpRequest.WithJsonBody((object)null!);
+            Action func = () => HttpRequest.WithJsonBody((object)null!);
 
             // Act & Assert.
-            Assert.Throws<ArgumentNullException>(Act);
+            func.Should().ThrowExactly<ArgumentNullException>();
         }
 
         [Fact]
@@ -36,8 +37,8 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
 
                 var convertedResponse = JsonSerializer.Deserialize<TestBody>(streamResponse.Result);
 
-                Assert.Equal("Bob Smith", convertedResponse.Name);
-                Assert.Equal(47, convertedResponse.Age);
+                convertedResponse.Name.Should().Be("Bob Smith");
+                convertedResponse.Age.Should().Be(47);
             });
 
             await HttpRequest

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithTextBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithTextBodyTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
@@ -9,17 +10,17 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
         [Fact]
         public void Null_Body_Results_In_An_Exception_Being_Thrown()
         {
-            void Act() => HttpRequest.WithTextBody(null);
+            Action func = () => HttpRequest.WithTextBody(null);
 
-            Assert.Throws<ArgumentNullException>(Act);
+            func.Should().ThrowExactly<ArgumentNullException>();
         }
 
         [Fact]
         public void Null_Content_Type_Results_In_An_Exception_Being_Thrown()
         {
-            void Act() => HttpRequest.WithTextBody("abc", "  ");
+            Action func = () => HttpRequest.WithTextBody("abc", "  ");
 
-            Assert.Throws<ArgumentNullException>(Act);
+            func.Should().ThrowExactly<ArgumentNullException>();
         }
 
         [Fact]
@@ -30,8 +31,8 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
                 var content = r.Content.ReadAsStringAsync();
                 content.Wait();
 
-                Assert.Equal("text/plain; charset=utf-8", r.Content.Headers.ContentType.ToString());
-                Assert.Equal("abc", content.Result);
+                r.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
+                content.Result.Should().Be("abc");
             });
 
             await HttpRequest

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriAsStringTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriAsStringTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.BuilderExtensionsTests
@@ -13,7 +14,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BuilderExtensionsTests
                 .WithQueryParameter("q", "how much does a pug snore")
                 .BuildUriAsString();
 
-            Assert.Equal("https://www.google.com/search?q=how+much+does+a+pug+snore", response);
+            response.Should().Be("https://www.google.com/search?q=how+much+does+a+pug+snore");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BuilderExtensionsTests/BuildUriTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.BuilderExtensionsTests
@@ -13,7 +14,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.BuilderExtensionsTests
                 .WithQueryParameter("q", "how much does a pug snore")
                 .BuildUri();
 
-            Assert.Equal("https://www.google.com/search?q=how+much+does+a+pug+snore", response.ToString());
+            response.ToString().Should().Be("https://www.google.com/search?q=how+much+does+a+pug+snore");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/GlobalStaticClientTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/GlobalStaticClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit
@@ -16,14 +17,14 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit
                 "response from a global client",
                 "text/plain"
             );
-            OnRequestMade(r => Assert.Contains("/global/http/test", r.RequestUri.OriginalString), messageHandlerResult);
+            OnRequestMade(r => r.RequestUri.OriginalString.Should().Contain("/global/http/test"), messageHandlerResult);
 
             var response = await "http://www.google.com".AsAGetRequest()
                 .WithPathSegment("global")
                 .WithPathSegment("http")
                 .WithPathSegment("test")
                 .ReadResponseAsStringAsync();
-            Assert.Equal("response from a global client", response);
+            response.Should().Be("response from a global client");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/ResponseContentTypeTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/ResponseContentTypeTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using Moq.Language.Flow;
 using Xunit;
@@ -25,7 +26,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
             {
                 var (handlerResult, request) = CreateBaseRequest();
 
-                OnRequestMade(r => Assert.Equal(methodAndExpected.expected, r.Headers.Accept.ToString()), handlerResult);
+                OnRequestMade(r => r.Headers.Accept.ToString().Should().Be(methodAndExpected.expected), handlerResult);
 
                 await methodAndExpected.Item1(request)
                     .EnsureSuccessStatusCodeAsync();
@@ -52,7 +53,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
             {
                 var (handlerResult, request) = CreateBaseRequest();
 
-                OnRequestMade(r => Assert.Equal(methodAndExpected.expected, r.Headers.Accept.ToString()), handlerResult);
+                OnRequestMade(r => r.Headers.Accept.ToString().Should().Be(methodAndExpected.expected), handlerResult);
 
                 await methodAndExpected.Item1(request)
                     .EnsureSuccessStatusCodeAsync();
@@ -75,7 +76,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
             {
                 var (handlerResult, request) = CreateBaseRequest();
 
-                OnRequestMade(r => Assert.Equal(methodAndExpected.expected, r.Headers.Accept.ToString()), handlerResult);
+                OnRequestMade(r => r.Headers.Accept.ToString().Should().Be(methodAndExpected.expected), handlerResult);
 
                 await methodAndExpected.Item1(request)
                     .EnsureSuccessStatusCodeAsync();

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBasicAuthTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBasicAuthTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
@@ -15,7 +16,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
                 var decodedString =
                     Encoding.UTF8.GetString(Convert.FromBase64String(r.Headers.Authorization.Parameter));
 
-                Assert.Equal("baseline:http", decodedString);
+                decodedString.Should().Be("baseline:http");
             });
 
             await HttpRequest

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBearerTokenAuthTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithBearerTokenAuthTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
@@ -10,7 +11,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
         [InlineData("Bearer foo")]
         public async Task Successfully_Adds_Authentication_And_Bearer_Token_Header(string token)
         {
-            OnRequestMade(r => Assert.Equal("Bearer foo", r.Headers.Authorization.ToString()));
+            OnRequestMade(r => r.Headers.Authorization.ToString().Should().Be("Bearer foo"));
 
             await HttpRequest
                 .WithBearerTokenAuth(token)

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithHeaderTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithHeaderTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
@@ -8,7 +9,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
         [Fact]
         public async Task With_Header_Successfully_Adds_A_New_Header()
         {
-            OnRequestMade(r => Assert.Equal("foo-bar", r.Headers.Authorization.Parameter));
+            OnRequestMade(r => r.Headers.Authorization.Parameter.Should().Be("foo-bar"));
 
             await HttpRequest
                 .WithRequestHeader("Authorization", "Bearer foo-bar")
@@ -19,7 +20,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
         [Fact]
         public async Task With_Header_Overwrites_An_Existing_Header()
         {
-            OnRequestMade(r => Assert.Equal("bar", r.Headers.Authorization.Parameter));
+            OnRequestMade(r => r.Headers.Authorization.Parameter.Should().Be("bar"));
 
             await HttpRequest
                 .WithRequestHeader("Authorization", "Bearer foo")

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithUserAgentTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HeaderExtensionsTests/WithUserAgentTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
@@ -8,7 +9,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.HeaderExtensionsTests
         [Fact]
         public async Task User_Agent_Is_Set_In_HttpRequest_Object()
         {
-            OnRequestMade(r => Assert.Equal("baseline", r.Headers.UserAgent.ToString()));
+            OnRequestMade(r => r.Headers.UserAgent.ToString().Should().Be("baseline"));
 
             await HttpRequest
                 .WithUserAgent("baseline")

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -10,22 +12,18 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Failed_Status_Code_Returns_An_Error()
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultFailure(mockMessageHandler);
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
-            async Task Act() => await request.EnsureSuccessStatusCodeAsync();
+            Func<Task> func = async () => await request.EnsureSuccessStatusCodeAsync();
 
-            // Assert.
-            await Assert.ThrowsAsync<HttpRequestException>(Act);
+            await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
         public async Task Good_Status_Code_Doesnt_Return_An_Error()
         {
-            // Arrange, Act & Assert.
             await HttpRequest.EnsureSuccessStatusCodeAsync();
         }
     }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/MakeRequestTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/MakeRequestTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
@@ -13,7 +14,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
                 .AsAGetRequest()
                 .MakeRequestAsync();
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -14,16 +16,13 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Checks_Success_Status_First()
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultFailure(mockMessageHandler);
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
-            async Task Act() => await request.ReadJsonResponseAsAsync<object>();
+            Func<Task> func = async () => await request.ReadJsonResponseAsAsync<object>();
 
-            // Assert.
-            await Assert.ThrowsAsync<HttpRequestException>(Act);
+            await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         // ReSharper disable once ClassNeverInstantiated.Local
@@ -37,18 +36,14 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [InlineData(@"{ ""name"": ""bob smith"" }")]
         public async Task Successfully_Resolves_Into_An_Object(string json)
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultSuccess(mockMessageHandler, json);
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
-            var response = await request
-                .ReadJsonResponseAsAsync<ResolvedObject>();
+            var response = await request.ReadJsonResponseAsAsync<ResolvedObject>();
 
-            // Assert.
-            Assert.NotNull(response);
-            Assert.Equal("bob smith", response.Name);
+            response.Should().NotBeNull();
+            response.Name.Should().Be("bob smith");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -10,31 +12,25 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Checks_Success_Response_First()
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultFailure(mockMessageHandler);
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
-            async Task Act() => await request.ReadResponseAsStringAsync();
+            Func<Task> func = async () => await request.ReadResponseAsStringAsync();
 
-            // Assert.
-            await Assert.ThrowsAsync<HttpRequestException>(Act);
+            await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
         public async Task Returns_String_Content_Successfully()
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultSuccess(mockMessageHandler, "hello world", "text/plain");
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
             var response = await request.ReadResponseAsStringAsync();
 
-            // Assert.
-            Assert.Equal("hello world", response);
+            response.Should().Be("hello world");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -11,32 +13,26 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Checks_Success_Status_First()
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultFailure(mockMessageHandler);
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
-            async Task Act() => await request.ReadXmlResponseAsAsync<object>();
+            Func<Task> func = async () => await request.ReadXmlResponseAsAsync<object>();
 
-            // Assert.
-            await Assert.ThrowsAsync<HttpRequestException>(Act);
+            await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
         public async Task Returns_Xml_Successfully()
         {
-            // Arrange.
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             ConfigureMessageHandlerResultSuccess(mockMessageHandler, "<foo><bar>abc</bar></foo>", "application/xml");
             var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
 
-            // Act.
             var response = await request.ReadXmlResponseAsAsync<TestXmlObject>();
 
-            // Assert.
-            Assert.NotNull(response);
-            Assert.Equal("abc", response.Bar);
+            response.Should().NotBeNull();
+            response.Bar.Should().Be("abc");
         }
     }
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/StringToHttpRequestExtensionsTests/StringToHttpRequestExtensionTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/StringToHttpRequestExtensionsTests/StringToHttpRequestExtensionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.StringToHttpRequestExtensionsTests
@@ -26,7 +27,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.StringToHttpRequestExtensions
         [MemberData(nameof(StringIntoRequestParams))]
         public async Task Can_Convert_A_String_Into_A_Request(Func<string, HttpClient, HttpRequest> func, HttpMethod expected)
         {
-            OnRequestMade(r => Assert.Equal(expected, r.Method));
+            OnRequestMade(r => r.Method.Should().Be(expected));
 
             await func(Url, HttpClient).EnsureSuccessStatusCodeAsync();
         }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithPathSegmentTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithPathSegmentTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
@@ -10,7 +11,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
         public async Task Can_Add_Multiple_Path_Segments()
         {
             var guid = Guid.NewGuid();
-            OnRequestMade(r => Assert.Contains($"/one/3/2/10/{guid}/18/25/{ulong.MaxValue}/fivebillion", r.RequestUri.ToString()));
+            OnRequestMade(r => r.RequestUri.ToString().Should().Contain($"/one/3/2/10/{guid}/18/25/{ulong.MaxValue}/fivebillion"));
 
             await HttpRequest
                 .WithPathSegment("one")
@@ -28,7 +29,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
         [Fact]
         public async Task Can_Add_Path_Segments_And_Query_String_Parameters()
         {
-            OnRequestMade(r => Assert.Contains("/one/three/two?a=1&b=2", r.RequestUri.ToString()));
+            OnRequestMade(r => r.RequestUri.ToString().Should().Contain("/one/three/two?a=1&b=2"));
 
             await HttpRequest
                 .WithPathSegment("one")

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithQueryParameterTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/UrlExtensionsTests/WithQueryParameterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
@@ -9,7 +10,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
         [Fact]
         public async Task Single_Query_Parameter_Can_Be_Added()
         {
-            OnRequestMade(r => Assert.Contains("?a=b", r.RequestUri.ToString()));
+            OnRequestMade(r => r.RequestUri.ToString().Should().Contain("?a=b"));
 
             await HttpRequest
                 .WithQueryParameter("a", "b")
@@ -21,9 +22,11 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
         {
             var guid = Guid.NewGuid();
 
-            OnRequestMade(r => Assert.Contains(
-                $"?a=b&foo=bar&name=bill&fin=0&fon=1&far=10&fun=32&bingo={guid}&bar=3&bus={ulong.MaxValue}",
-                r.RequestUri.ToString()));
+            OnRequestMade(r => r.RequestUri
+                .ToString()
+                .Should()
+                .Contain($"?a=b&foo=bar&name=bill&fin=0&fon=1&far=10&fun=32&bingo={guid}&bar=3&bus={ulong.MaxValue}")
+            );
 
             await HttpRequest
                 .WithQueryParameter("a", "b")
@@ -42,7 +45,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
         [Fact]
         public async Task Can_Add_Same_Parameter_More_Than_Once()
         {
-            OnRequestMade(r => Assert.Contains("?a=b&a=c&c=5&c=55", r.RequestUri.ToString()));
+            OnRequestMade(r => r.RequestUri.ToString().Should().Contain("?a=b&a=c&c=5&c=55"));
 
             await HttpRequest
                 .WithQueryParameter("a", "b")
@@ -55,7 +58,7 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.UrlExtensionsTests
         [Fact]
         public async Task Invalid_Or_Empty_Query_String_Value_Is_Not_Added()
         {
-            OnRequestMade(r => Assert.Contains("?b=1&d=3", r.RequestUri.ToString()));
+            OnRequestMade(r => r.RequestUri.ToString().Should().Contain("?b=1&d=3"));
 
             await HttpRequest
                 .WithQueryParameter("a", null)


### PR DESCRIPTION
Installed FluentAssertions in test projects.

Converted standard XUnit assertions (i.e. Assert.Equal) to their
fluent equivalent.