### PR TITLE
ISSUE-53 - Add ability to read the response as a stream.

### DIFF
--- a/BaselineFluentHttpExtensions.cs
+++ b/BaselineFluentHttpExtensions.cs
@@ -328,13 +328,27 @@ namespace Baseline.FluentHttpExtensions
     public static class HttpResponseMessageExtensions
     {
         /// <summary>
+        /// Reads the response's content as a stream.
+        /// </summary>
+        /// <param name="response">The response message.</param>
+        /// <returns>The response as a stream.</returns>
+        public static async Task<Stream> ReadResponseAsStreamAsync(this HttpResponseMessage response)
+        {
+            var stream = new MemoryStream();
+            using (var contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            {
+                contentStream.Seek(0, SeekOrigin.Begin);
+                await contentStream.CopyToAsync(stream).ConfigureAwait(false);
+            }
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream;
+        }
+        /// <summary>
         /// Reads the response's content as a string.
         /// </summary>
         /// <param name="response">The response message.</param>
         /// <returns>An awaitable task yielding the response as a string.</returns>
-        public static async Task<string> ReadResponseAsStringAsync(
-            this HttpResponseMessage response
-        )
+        public static async Task<string> ReadResponseAsStringAsync(this HttpResponseMessage response)
         {
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
@@ -352,27 +366,29 @@ namespace Baseline.FluentHttpExtensions
             CancellationToken token = default
         )
         {
-            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            stream.Seek(0, SeekOrigin.Begin);
-            return await JsonSerializer.DeserializeAsync<T>(
-                stream,
-                jsonSerializerOptions ?? new JsonSerializerOptions { PropertyNameCaseInsensitive = true },
-                token
-            ).ConfigureAwait(false);
+            using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                return await JsonSerializer.DeserializeAsync<T>(
+                    stream,
+                    jsonSerializerOptions ?? new JsonSerializerOptions {PropertyNameCaseInsensitive = true},
+                    token
+                ).ConfigureAwait(false);
+            }
         }
         /// <summary>
         /// Deserializes the XML response into an object.
         /// </summary>
         /// <param name="response">The response to retrieve the content from and deserialize.</param>
         /// <returns>The deserialized representation of the XML, or null if it could not be casted.</returns>
-        public static async Task<T> ReadXmlResponseAsAsync<T>(
-            this HttpResponseMessage response
-        ) where T : class
+        public static async Task<T> ReadXmlResponseAsAsync<T>(this HttpResponseMessage response)
         {
-            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            stream.Seek(0, SeekOrigin.Begin);
-            var xmlSerializer = new XmlSerializer(typeof(T));
-            return xmlSerializer.Deserialize(stream) as T;
+            using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                var xmlSerializer = new XmlSerializer(typeof(T));
+                return (T) xmlSerializer.Deserialize(stream);
+            }
         }
     }
 }
@@ -472,7 +488,8 @@ namespace Baseline.FluentHttpExtensions
     public static class SendTriggeringExtensions
     {
         /// <summary>
-        /// Makes and performs a request using the configured parameters.
+        /// Makes and performs a request using the configured parameters. You are responsible for managing the
+        /// disposal lifetimes of the response when using this method.
         /// </summary>
         /// <param name="request">The current <see cref="HttpRequest"/>.</param>
         /// <param name="token">The optional cancellation token</param>
@@ -513,13 +530,32 @@ namespace Baseline.FluentHttpExtensions
             }
         }
         /// <summary>
+        /// Makes a request and reads the response as a stream. This method first ensures that the status code returned
+        /// is a successful one.
+        /// </summary>
+        /// <param name="request">The configured request to make.</param>
+        /// <param name="token">The optional cancellation token.</param>
+        /// <returns>The response as a stream.</returns>
+        public static async Task<Stream> ReadResponseAsStreamAsync(
+            this HttpRequest request,
+            CancellationToken token = default
+        )
+        {
+            using (var response = await request.MakeRequestAsync(token).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                return await response.ReadResponseAsStreamAsync();
+            }
+        }
+        /// <summary>
         /// Makes the request and reads the response as a string. This method first ensures that the status code
         /// returned is a successful one.
         /// </summary>
         /// <param name="request">The configured request to make.</param>
         /// <param name="token">The optional cancellation token</param>
         /// <returns>An awaitable task yielding the response as a string.</returns>
-        public static async Task<string> ReadResponseAsStringAsync(this HttpRequest request,
+        public static async Task<string> ReadResponseAsStringAsync(
+            this HttpRequest request,
             CancellationToken token = default)
         {
             using (var response = await request.MakeRequestAsync(token).ConfigureAwait(false))

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
@@ -19,20 +19,24 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
             response.Should().Contain("This is a test");
         }
 
-        [Fact]
-        public async Task Can_Make_A_Request_With_Basic_Auth()
+        [Theory]
+        [InlineData("postman", "password", false)]
+        [InlineData("postman", "wrong", true)]
+        public async Task Can_Make_A_Request_With_Basic_Auth(string username, string password, bool shouldThrow)
         {
-            await "https://postman-echo.com/basic-auth"
-                .AsAGetRequest(new HttpClient())
-                .WithBasicAuth("postman", "password")
-                .EnsureSuccessStatusCodeAsync();
-
             Func<Task> func = async () => await "https://postman-echo.com/basic-auth"
                 .AsAGetRequest(new HttpClient())
-                .WithBasicAuth("postman", "wrong-pwd")
+                .WithBasicAuth(username, password)
                 .EnsureSuccessStatusCodeAsync();
 
-            await func.Should().ThrowExactlyAsync<HttpRequestException>();
+            if (shouldThrow)
+            {
+                await func.Should().ThrowExactlyAsync<HttpRequestException>();
+            }
+            else
+            {
+                await func.Should().NotThrowAsync();
+            }
         }
 
         [Fact]

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStreamTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStreamTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
+{
+    public class ReadResponseAsStreamTests : UnitTest
+    {
+        [Fact]
+        public async Task Checks_Success_Response_First()
+        {
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            ConfigureMessageHandlerResultFailure(mockMessageHandler);
+            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+
+            Func<Task> act = async () => await request.ReadResponseAsStreamAsync();
+
+            await act.Should().ThrowExactlyAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task Returns_Stream_Content_Successfully()
+        {
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            ConfigureMessageHandlerResultSuccess(mockMessageHandler, "hello world", "text/plain");
+            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+
+            var response = await request.ReadResponseAsStreamAsync();
+            var streamReader = new StreamReader(response);
+
+            (await streamReader.ReadToEndAsync()).Should().Be("hello world");
+        }
+    }
+}


### PR DESCRIPTION
Added the ReadResponseAsStreamAsync method to both the SendTriggeringExtensions
and the HttpResponseMessageExtensions extension classes.

Wrote tests for both.

Updated documentation to make it clear who is responsible for resource
management when using the MakeRequest method.

Tidied up a test to use a theory instead.

Fixes #53 