### PR TITLE
ISSUE-55 - Allow HttpResponseMessage extensions to be called multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ format. Under the hood, this method utilises the `BuildUri` extension method.
 **Send Triggering Methods**
 
 The send triggering methods perform the actual request to the configured endpoint. For that reason, they do not
-continue the fluent interface and return response types relevant to their methods.
+continue the fluent interface and return response types relevant to their methods. These methods dispose of the
+request automatically, and all methods except `MakeRequestAsync` will dispose of the response too. For most users, this
+will not cause any issues. However, if you are passing a stream around as a request body, for example, you may find
+it is disposed of by the below methods. To counter-act this, ensure you specify the `copyStream` parameter
+as true when using a stream as the request body.
 
 * `Task<HttpResponseMessage> MakeRequestAsync()` - Performs the request using the configured parameters and returns the
 response. Warning: when using this method, you are responsible for the lifetime of the returned response. Make sure you
@@ -182,7 +186,11 @@ Occasionally, you may want to perform more than one action on a `HttpResponseMes
 method. The following methods allow you to do that against a `HttpResponseMessage` saved in a variable multiple times,
 without having to make the request again.
 
-* `Task<Stream> ReadResponseAsStreamAsync()` - Reads the content of the response as a stream.
+These methods do not dispose of the response, and returns that responsibility to you, the consumer of the library.
+
+* `Task<Stream> ReadResponseAsStreamAsync()` - Reads the content of the response as a stream. The stream is copied into
+a memory stream, and as such can be read multiple times and passed outside of a using scope without causing
+any issues as a result of the original stream being disposed.
 
 * `Task<string> ReadResponseAsStringAsync()` - Reads the content of the response as a string.
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HttpResponseMessageExtensionsTests/ReadJsonResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HttpResponseMessageExtensionsTests/ReadJsonResponseAsTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.HttpResponseMessageExtensionsTests
+{
+    public class ReadJsonResponseAsTests : UnitTest
+    {
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class ResolvedObject
+        {
+            public string Name { get; set; }
+        }
+
+        [Fact]
+        public async Task It_Does_Not_Dispose_Of_The_Original_Content_Stream()
+        {
+            ConfigureMessageHandlerResultSuccess(MessageHandler, @"{ ""Name"": ""bob smith"" }");
+
+            var completedRequest = await HttpRequest.MakeRequestAsync();
+
+            var response = await completedRequest.ReadJsonResponseAsAsync<ResolvedObject>();
+            response.Should().NotBeNull();
+            response.Name.Should().Be("bob smith");
+
+            response = await completedRequest.ReadJsonResponseAsAsync<ResolvedObject>();
+            response.Should().NotBeNull();
+            response.Name.Should().Be("bob smith");
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HttpResponseMessageExtensionsTests/ReadResponseAsStreamAsyncTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HttpResponseMessageExtensionsTests/ReadResponseAsStreamAsyncTests.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.HttpResponseMessageExtensionsTests
+{
+    public class ReadResponseAsStreamTests : UnitTest
+    {
+        [Fact]
+        public async Task It_Does_Not_Dispose_Of_The_Original_Content_Stream()
+        {
+            ConfigureMessageHandlerResultSuccess(MessageHandler, "hello world", "text/plain");
+
+            var request = await HttpRequest.MakeRequestAsync();
+
+            var response = await request.ReadResponseAsStreamAsync();
+            var streamReader = new StreamReader(response);
+            (await streamReader.ReadToEndAsync()).Should().Be("hello world");
+
+            response = await request.ReadResponseAsStreamAsync();
+            streamReader = new StreamReader(response);
+            (await streamReader.ReadToEndAsync()).Should().Be("hello world");
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/HttpResponseMessageExtensionsTests/ReadXmlResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/HttpResponseMessageExtensionsTests/ReadXmlResponseAsTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using FluentAssertions;
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.HttpResponseMessageExtensionsTests
+{
+    public class ReadXmlResponseAsTests : UnitTest
+    {
+        [XmlRoot("foo")]
+        public class TestXmlObject
+        {
+            [XmlElement("bar")]
+            public string Bar { get; set; }
+        }
+
+        [Fact]
+        public async Task It_Does_Not_Dispose_Of_The_Original_Content_Stream()
+        {
+            ConfigureMessageHandlerResultSuccess(MessageHandler, "<foo><bar>abc</bar></foo>", "application/xml");
+
+            var request = await HttpRequest.MakeRequestAsync();
+
+            var response = await request.ReadXmlResponseAsAsync<TestXmlObject>();
+            response.Should().NotBeNull();
+            response.Bar.Should().Be("abc");
+
+            response = await request.ReadXmlResponseAsAsync<TestXmlObject>();
+            response.Should().NotBeNull();
+            response.Bar.Should().Be("abc");
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/EnsureSuccessStatusCodeTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
@@ -12,12 +11,9 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Failed_Status_Code_Returns_An_Error()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultFailure(mockMessageHandler);
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultFailure(MessageHandler);
 
-            Func<Task> func = async () => await request.EnsureSuccessStatusCodeAsync();
-
+            Func<Task> func = async () => await HttpRequest.EnsureSuccessStatusCodeAsync();
             await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadJsonResponseAsTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 // ReSharper disable NotNullMemberIsNotInitialized
@@ -16,12 +15,9 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Checks_Success_Status_First()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultFailure(mockMessageHandler);
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultFailure(MessageHandler);
 
-            Func<Task> func = async () => await request.ReadJsonResponseAsAsync<object>();
-
+            Func<Task> func = async () => await HttpRequest.ReadJsonResponseAsAsync<object>();
             await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
@@ -36,12 +32,9 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [InlineData(@"{ ""name"": ""bob smith"" }")]
         public async Task Successfully_Resolves_Into_An_Object(string json)
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultSuccess(mockMessageHandler, json);
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultSuccess(MessageHandler, json);
 
-            var response = await request.ReadJsonResponseAsAsync<ResolvedObject>();
-
+            var response = await HttpRequest.ReadJsonResponseAsAsync<ResolvedObject>();
             response.Should().NotBeNull();
             response.Name.Should().Be("bob smith");
         }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStreamTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStreamTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
@@ -13,23 +12,18 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Checks_Success_Response_First()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultFailure(mockMessageHandler);
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultFailure(MessageHandler);
 
-            Func<Task> act = async () => await request.ReadResponseAsStreamAsync();
-
+            Func<Task> act = async () => await HttpRequest.ReadResponseAsStreamAsync();
             await act.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
         public async Task Returns_Stream_Content_Successfully()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultSuccess(mockMessageHandler, "hello world", "text/plain");
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultSuccess(MessageHandler, "hello world", "text/plain");
 
-            var response = await request.ReadResponseAsStreamAsync();
+            var response = await HttpRequest.ReadResponseAsStreamAsync();
             var streamReader = new StreamReader(response);
 
             (await streamReader.ReadToEndAsync()).Should().Be("hello world");

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadResponseAsStringTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
@@ -12,24 +11,18 @@ namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
         [Fact]
         public async Task Checks_Success_Response_First()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultFailure(mockMessageHandler);
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultFailure(MessageHandler);
 
-            Func<Task> func = async () => await request.ReadResponseAsStringAsync();
-
+            Func<Task> func = async () => await HttpRequest.ReadResponseAsStringAsync();
             await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
         public async Task Returns_String_Content_Successfully()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultSuccess(mockMessageHandler, "hello world", "text/plain");
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultSuccess(MessageHandler, "hello world", "text/plain");
 
-            var response = await request.ReadResponseAsStringAsync();
-
+            var response = await HttpRequest.ReadResponseAsStringAsync();
             response.Should().Be("hello world");
         }
     }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/SendTriggeringExtensionsTests/ReadXmlResponseAsTests.cs
@@ -3,43 +3,36 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Baseline.FluentHttpExtensions.Tests.Unit.SendTriggeringExtensionsTests
 {
     public class ReadXmlResponseAsTests : UnitTest
     {
+        [XmlRoot("foo")]
+        public class TestXmlObject
+        {
+            [XmlElement("bar")]
+            public string Bar { get; set; }
+        }
+
         [Fact]
         public async Task Checks_Success_Status_First()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultFailure(mockMessageHandler);
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultFailure(MessageHandler);
 
-            Func<Task> func = async () => await request.ReadXmlResponseAsAsync<object>();
-
+            Func<Task> func = async () => await HttpRequest.ReadXmlResponseAsAsync<object>();
             await func.Should().ThrowExactlyAsync<HttpRequestException>();
         }
 
         [Fact]
         public async Task Returns_Xml_Successfully()
         {
-            var mockMessageHandler = new Mock<HttpMessageHandler>();
-            ConfigureMessageHandlerResultSuccess(mockMessageHandler, "<foo><bar>abc</bar></foo>", "application/xml");
-            var request = new HttpRequest(RequestUrl, new HttpClient(mockMessageHandler.Object));
+            ConfigureMessageHandlerResultSuccess(MessageHandler, "<foo><bar>abc</bar></foo>", "application/xml");
 
-            var response = await request.ReadXmlResponseAsAsync<TestXmlObject>();
-
+            var response = await HttpRequest.ReadXmlResponseAsAsync<TestXmlObject>();
             response.Should().NotBeNull();
             response.Bar.Should().Be("abc");
         }
-    }
-
-    [XmlRoot("foo")]
-    public class TestXmlObject
-    {
-        [XmlElement("bar")]
-        public string Bar { get; set; }
     }
 }

--- a/src/Baseline.FluentHttpExtensions/HttpResponseMessageExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/HttpResponseMessageExtensions.cs
@@ -14,7 +14,8 @@ namespace Baseline.FluentHttpExtensions
     public static class HttpResponseMessageExtensions
     {
         /// <summary>
-        /// Reads the response's content as a stream.
+        /// Reads the response's content as a stream. The new stream is entirely disconnected from the lifecycle of
+        /// <see cref="HttpContent"/>.
         /// </summary>
         /// <param name="response">The response message.</param>
         /// <returns>The response as a stream.</returns>
@@ -22,11 +23,9 @@ namespace Baseline.FluentHttpExtensions
         {
             var stream = new MemoryStream();
 
-            using (var contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            {
-                contentStream.Seek(0, SeekOrigin.Begin);
-                await contentStream.CopyToAsync(stream).ConfigureAwait(false);
-            }
+            var contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            contentStream.Seek(0, SeekOrigin.Begin);
+            await contentStream.CopyToAsync(stream).ConfigureAwait(false);
 
             stream.Seek(0, SeekOrigin.Begin);
             return stream;
@@ -56,16 +55,14 @@ namespace Baseline.FluentHttpExtensions
             CancellationToken token = default
         )
         {
-            using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            {
-                stream.Seek(0, SeekOrigin.Begin);
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            stream.Seek(0, SeekOrigin.Begin);
 
-                return await JsonSerializer.DeserializeAsync<T>(
-                    stream,
-                    jsonSerializerOptions ?? new JsonSerializerOptions {PropertyNameCaseInsensitive = true},
-                    token
-                ).ConfigureAwait(false);
-            }
+            return await JsonSerializer.DeserializeAsync<T>(
+                stream,
+                jsonSerializerOptions ?? new JsonSerializerOptions {PropertyNameCaseInsensitive = true},
+                token
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -75,13 +72,11 @@ namespace Baseline.FluentHttpExtensions
         /// <returns>The deserialized representation of the XML, or null if it could not be casted.</returns>
         public static async Task<T> ReadXmlResponseAsAsync<T>(this HttpResponseMessage response)
         {
-            using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            {
-                stream.Seek(0, SeekOrigin.Begin);
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            stream.Seek(0, SeekOrigin.Begin);
 
-                var xmlSerializer = new XmlSerializer(typeof(T));
-                return (T) xmlSerializer.Deserialize(stream);
-            }
+            var xmlSerializer = new XmlSerializer(typeof(T));
+            return (T) xmlSerializer.Deserialize(stream);
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions/SendTriggeringExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/SendTriggeringExtensions.cs
@@ -1,10 +1,8 @@
-using System;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace Baseline.FluentHttpExtensions
 {
@@ -25,24 +23,25 @@ namespace Baseline.FluentHttpExtensions
             CancellationToken token = default
         )
         {
-            var actualRequest = new HttpRequestMessage(request.HttpMethod, request.BuildUri());
-
-            // Build headers.
-            if (request.Headers != null)
+            using (var actualRequest = new HttpRequestMessage(request.HttpMethod, request.BuildUri()))
             {
-                foreach (var header in request.Headers)
+                // Build headers.
+                if (request.Headers != null)
                 {
-                    actualRequest.Headers.Add(header.Key, header.Value);
+                    foreach (var header in request.Headers)
+                    {
+                        actualRequest.Headers.Add(header.Key, header.Value);
+                    }
                 }
-            }
 
-            // Set body.
-            if (request.GetBodyContentAsync != null)
-            {
-                actualRequest.Content = await request.GetBodyContentAsync(token);
-            }
+                // Set body.
+                if (request.GetBodyContentAsync != null)
+                {
+                    actualRequest.Content = await request.GetBodyContentAsync(token);
+                }
 
-            return await request.HttpClient.SendAsync(actualRequest, token).ConfigureAwait(false);
+                return await request.HttpClient.SendAsync(actualRequest, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added the ReadResponseAsStreamAsync method to both the SendTriggeringExtensions
and the HttpResponseMessageExtensions extension classes.

Wrote tests for both.

Updated documentation to make it clear who is responsible for resource
management when using the MakeRequest method.

Tidied up a test to use a theory instead.

Fixes #55 